### PR TITLE
refactor(options/components/App): improve dataAttribute setting

### DIFF
--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -16,7 +16,7 @@
             <div class="settings-group">
               <label class="settings-label">custom data attribute</label>
               <input id="options-code-dataAttribute" type="text" v-model.trim="options.code.dataAttribute" @change="save" placeholder="your custom data-* attribute">
-              <small>Define a attribute that we'll attempt to use when selecting the elements. This is handy
+              <small>Define an attribute that we'll attempt to use when selecting the elements, i.e "data-custom". This is handy
                 when React or Vue based apps generate random class names.</small>
             </div>
           </div>

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -15,8 +15,8 @@
           <div class="settings-block-main">
             <div class="settings-group">
               <label class="settings-label">custom data attribute</label>
-              <input id="options-code-dataAttribute" type="text" v-model="options.code.dataAttribute" @change="save" placeholder="your custom data-* attribute">
-              <small>Define a <code>data-*</code> attribute that we'll attempt to use when selecting the elements. This is handy
+              <input id="options-code-dataAttribute" type="text" v-model.trim="options.code.dataAttribute" @change="save" placeholder="your custom data-* attribute">
+              <small>Define a attribute that we'll attempt to use when selecting the elements. This is handy
                 when React or Vue based apps generate random class names.</small>
             </div>
           </div>


### PR DESCRIPTION
# Pull Request Template

## Description

1. Remove `data-*` of dataAttribute description, it's hard to understand, not only `data-*`, all attribute work.
2. Trim `dataAttribute` setting.

## Type of change

- [x] Refactor  (non-breaking change)

## How Has This Been Tested?

Spaces do not affect `dataAttribute` settings

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
