### PR TITLE
fix: page.selectOption on playwright

### DIFF
--- a/src/code-generator/PlaywrightCodeGenerator.js
+++ b/src/code-generator/PlaywrightCodeGenerator.js
@@ -32,4 +32,8 @@ export default class PlaywrightCodeGenerator extends CodeGenerator {
   _handleViewport (width, height) {
     return new Block(this._frameId, { type: pptrActions.VIEWPORT, value: `await ${this._frame}.setViewportSize({ width: ${width}, height: ${height} })` })
   }
+
+  _handleChange (selector, value) {
+    return new Block(this._frameId, { type: pptrActions.CHANGE, value: `await ${this._frame}.selectOption('${selector}', '${value}')` })
+  }
 }

--- a/src/code-generator/__tests__/PlaywrightCodeGenerator.spec.js
+++ b/src/code-generator/__tests__/PlaywrightCodeGenerator.spec.js
@@ -6,4 +6,10 @@ describe('PlaywrightCodeGenerator', () => {
     const codeGenerator = new PlaywrightCodeGenerator()
     expect(codeGenerator._parseEvents(events)).toBeFalsy()
   })
+
+  test('it generates a page.selectOption() only for select dropdowns', () => {
+    const events = [{ action: 'change', selector: 'select#animals', tagName: 'SELECT', value: 'hamster' }]
+    const codeGenerator = new PlaywrightCodeGenerator()
+    expect(codeGenerator._parseEvents(events)).toContain(`await page.selectOption('${events[0].selector}', '${events[0].value}')`)
+  })
 })


### PR DESCRIPTION
# Pull Request Template

## Description

Use correct playwright API to fill a select using `page.selectOption(selector, value)`.
Closes #104 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
