### PR TITLE
feat: able to specify custom key for input record

### DIFF
--- a/src/code-generator/CodeGenerator.js
+++ b/src/code-generator/CodeGenerator.js
@@ -9,7 +9,8 @@ export const defaults = {
   waitForSelectorOnClick: true,
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
-  showPlaywrightFirst: false
+  showPlaywrightFirst: false,
+  keyCode: 9
 }
 
 export default class CodeGenerator {
@@ -53,7 +54,7 @@ export default class CodeGenerator {
 
       switch (action) {
         case 'keydown':
-          if (keyCode === 9) { // tab key
+          if (keyCode === this._options.keyCode) {
             this._blocks.push(this._handleKeyDown(selector, value, keyCode))
           }
           break

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -19,6 +19,14 @@
               <small>Define an attribute that we'll attempt to use when selecting the elements, i.e "data-custom". This is handy
                 when React or Vue based apps generate random class names.</small>
             </div>
+            <div class="settings-group">
+              <label class="settings-label">set key code</label>
+              <div class="settings-block">
+                <button class="btn btn-sm btn-primary" @click="listenForKeyCodePress">{{ recordingKeyCodePress ? 'Capturing' : 'Click to capture key code'}}</button>
+                <input id="options-code-keyCode" readonly disabled type="number" v-model.number="options.code.keyCode" placeholder="Key Code for input fields (ex. 9 = Tab)">
+              </div>
+              <small>What key will be used for capturing input changes. The value here is the key code. This will not handle multiple keys.</small>
+            </div>
           </div>
         </div>
         <div class="settings-block">
@@ -106,7 +114,8 @@
       return {
         loading: true,
         saving: false,
-        options: defaults
+        options: defaults,
+        recordingKeyCodePress: false
       }
     },
     mounted () {
@@ -130,6 +139,20 @@
           }
           this.loading = false
         })
+      },
+      listenForKeyCodePress () {
+        this.recordingKeyCodePress = true
+        const keyDownFunction = e => {
+          this.recordingKeyCodePress = false
+          this.updateKeyCodeWithNumber(e)
+          window.removeEventListener('keydown', keyDownFunction, false)
+          e.preventDefault();
+        }
+        window.addEventListener('keydown', keyDownFunction, false)
+      },
+      updateKeyCodeWithNumber (evt) {
+        this.options.code.keyCode = parseInt(evt.keyCode, 10);
+        this.save()
       }
     }
   }
@@ -206,7 +229,7 @@
             display: block;
           }
         }
-        input[type="text"] {
+        input[type="text"], input[type="number"] {
           margin-bottom: 10px;
           width: 100%;
           border: 1px solid $gray-light;
@@ -215,6 +238,9 @@
           font-size: 14px;
           border-radius: 10px;
           -webkit-box-sizing: border-box;
+        }
+        input[type="number"] {
+          width: 50px;
         }
       }
     }

--- a/src/options/components/__tests__/App.spec.js
+++ b/src/options/components/__tests__/App.spec.js
@@ -33,6 +33,28 @@ describe('App.vue', () => {
     expect(wrapper.vm.$data.options.code.wrapAsync).toBeTruthy()
   })
 
+  test('it has the default key code for capturing inputs as 9 (Tab)', () => {
+    const mocks = { $chrome: createChromeLocalStorageMock() }
+    const wrapper = mount(App, { mocks, localVue })
+    expect(wrapper.vm.$data.options.code.keyCode).toBe(9)
+  })
+
+  test('clicking the button will listen for the next keydown and update the key code option', () => {
+    const options = { code: { keyCode: 9 } }
+    const mocks = { $chrome: createChromeLocalStorageMock(options) }
+    const wrapper = mount(App, { mocks, localVue })
+    return wrapper.vm.$nextTick()
+      .then(() => {
+        wrapper.find('button').element.click()
+        const event = new KeyboardEvent('keydown', { keyCode: 16 })
+        window.dispatchEvent(event)
+        return wrapper.vm.$nextTick()
+      })
+      .then(() => {
+        expect(wrapper.vm.$data.options.code.keyCode).toBe(16)
+      })
+  })
+
   test('it stores and loads the user\'s edited options', () => {
     const options = { code: { wrapAsync: true } }
     const mocks = { $chrome: createChromeLocalStorageMock(options) }


### PR DESCRIPTION
# Pull Request Template

## Description

Added the ability to change the keyboard command for recording input changes.  By default this is TAB.  There are a few closed issues that had discussion about how to remedy the tabbing and losing focus, but no solution.

This change allows users to change what key to finish input record to what they want.  For instance I found SHIFT to be a better key.

This adds a button in the options menu, where a user clicks it and the extension listens for the next key down event.
I'm not a big fan of displaying the key code instead of the actual key but I didn't want to store both as one is only for display purposes.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update
This is up for debate, the documentation does mention the TAB key

## How Has This Been Tested?

Ran the entire test suite that's provided and added unit tests to cover the new changes.

## Checklist:

- [X] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
