### PR TITLE
fix(code-generator): fix input escaping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "headless-recorder",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/code-generator/CodeGenerator.js
+++ b/src/code-generator/CodeGenerator.js
@@ -128,7 +128,7 @@ export default class CodeGenerator {
 
   _handleKeyDown (selector, value) {
     const block = new Block(this._frameId)
-    block.addLine({ type: domEvents.KEYDOWN, value: `await ${this._frame}.type('${selector}', '${value}')` })
+    block.addLine({ type: domEvents.KEYDOWN, value: `await ${this._frame}.type('${selector}', '${this._escapeUserInput(value)}')` })
     return block
   }
 
@@ -206,5 +206,9 @@ export default class CodeGenerator {
       this._blocks.splice(i, 0, blankLine)
       i += 2
     }
+  }
+
+  _escapeUserInput (value) {
+    return value.replace(/\\/g, '\\\\').replace(/'/g, '\\\'')
   }
 }

--- a/src/code-generator/__tests__/PuppeteerCodeGenerator.spec.js
+++ b/src/code-generator/__tests__/PuppeteerCodeGenerator.spec.js
@@ -86,4 +86,12 @@ describe('PuppeteerCodeGenerator', () => {
 
     expect(result).toContain("await page.screenshot({ path: 'screenshot_1.png', clip: { x: 10, y: 300, width: 800, height: 600 } })")
   })
+
+  test('it generates the correct escaped value', () => {
+    const events = [{ action: 'keydown', keyCode: 9, selector: 'input.value', value: "hello');console.log('world" }]
+    const codeGenerator = new PuppeteerCodeGenerator()
+    const result = codeGenerator._parseEvents(events)
+
+    expect(result).toContain("await page.type('input.value', 'hello\\');console.log(\\'world')")
+  })
 })


### PR DESCRIPTION
# Pull Request Template

## Description
If a user types in a string with single quote(s) or backward slash(es) while recording, it is not escaped correctly and leaks into the generated code. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All existing tests passed. Manually tested with the following strings:

- hello''
- hello\\
- hello\\world
- hello\\''world
- hello');console.log('world

And added new unit test for it. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
