### PR TITLE
fix escaping of backslash in selector

### DIFF
--- a/src/code-generator/CodeGenerator.js
+++ b/src/code-generator/CodeGenerator.js
@@ -48,6 +48,7 @@ export default class CodeGenerator {
 
     for (let i = 0; i < events.length; i++) {
       const { action, selector, value, href, keyCode, tagName, frameId, frameUrl } = events[i]
+      const escapedSelector = selector ? selector.replace(/\\/g, '\\\\') : selector
 
       // we need to keep a handle on what frames events originate from
       this._setFrames(frameId, frameUrl)
@@ -55,15 +56,15 @@ export default class CodeGenerator {
       switch (action) {
         case 'keydown':
           if (keyCode === this._options.keyCode) {
-            this._blocks.push(this._handleKeyDown(selector, value, keyCode))
+            this._blocks.push(this._handleKeyDown(escapedSelector, value, keyCode))
           }
           break
         case 'click':
-          this._blocks.push(this._handleClick(selector, events))
+          this._blocks.push(this._handleClick(escapedSelector, events))
           break
         case 'change':
           if (tagName === 'SELECT') {
-            this._blocks.push(this._handleChange(selector, value))
+            this._blocks.push(this._handleChange(escapedSelector, value))
           }
           break
         case pptrActions.GOTO:

--- a/src/code-generator/__tests__/PuppeteerCodeGenerator.spec.js
+++ b/src/code-generator/__tests__/PuppeteerCodeGenerator.spec.js
@@ -94,4 +94,12 @@ describe('PuppeteerCodeGenerator', () => {
 
     expect(result).toContain("await page.type('input.value', 'hello\\');console.log(\\'world')")
   })
+
+  test('it generates the correct escaped value with backslash', () => {
+    const events = [{ action: 'click', selector: 'button.\\hello\\' }]
+    const codeGenerator = new PuppeteerCodeGenerator()
+    const result = codeGenerator._parseEvents(events)
+
+    expect(result).toContain("await page.click('button.\\\\hello\\\\')")
+  })
 })


### PR DESCRIPTION
# Pull Request Template

## Description

This patch fixes `CodeGenerator.__parseEvents` so that it works with backslash within selector.  (issue: #110 )

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
New test code was added for this change.


## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
