### PR TITLE
Give precedence to data-* and trust in ID's uniqueness

### DIFF
--- a/src/content-scripts/EventRecorder.js
+++ b/src/content-scripts/EventRecorder.js
@@ -100,21 +100,15 @@ export default class EventRecorder {
     // we explicitly catch any errors and swallow them, as none node-type events are also ingested.
     // for these events we cannot generate selectors, which is OK
     try {
-      const optimizedMinLength = (e.target.id) ? 2 : 10 // if the target has an id, use that instead of multiple other selectors
-      const selector = this._dataAttribute
-        ? finder(e.target, {seedMinLength: 5, optimizedMinLength: optimizedMinLength, attr: (name, _value) => name === this._dataAttribute})
-        : finder(e.target, {seedMinLength: 5, optimizedMinLength: optimizedMinLength})
-
-      const msg = {
-        selector: selector,
+      this._sendMessage({
+        selector: this._getSelector(e),
         value: e.target.value,
         tagName: e.target.tagName,
         action: e.type,
         keyCode: e.keyCode ? e.keyCode : null,
         href: e.target.href ? e.target.href : null,
         coordinates: EventRecorder._getCoordinates(e)
-      }
-      this._sendMessage(msg)
+      })
     } catch (e) {}
   }
 
@@ -156,6 +150,22 @@ export default class EventRecorder {
     this._isRecordingClicks = true
   }
 
+  _getSelector (e) {
+    if (this._dataAttribute && e.target.getAttribute(this._dataAttribute)) {
+      return `[${this._dataAttribute}="${e.target.getAttribute(this._dataAttribute)}"]`
+    }
+
+    if (e.target.id) {
+      return `#${e.target.id}`
+    }
+
+    return finder(e.target, {
+      seedMinLength: 5,
+      optimizedMinLength: (e.target.id) ? 2 : 10,
+      attr: (name, _value) => name === this._dataAttribute
+    })
+  }
+
   static _getCoordinates (evt) {
     const eventsWithCoordinates = {
       mouseup: true,
@@ -164,9 +174,5 @@ export default class EventRecorder {
       mouseover: true
     }
     return eventsWithCoordinates[evt.type] ? { x: evt.clientX, y: evt.clientY } : null
-  }
-
-  static _formatDataSelector (element, attribute) {
-    return `[${attribute}="${element.getAttribute(attribute)}"]`
   }
 }

--- a/src/content-scripts/__tests__/attributes.spec.js
+++ b/src/content-scripts/__tests__/attributes.spec.js
@@ -48,4 +48,20 @@ describe('attributes', () => {
     const event = (await waitForAndGetEvents(page, 1))[0]
     expect(event.selector).toEqual('body > #content-root > [data-qa="article-wrapper"] > [data-qa="article-body"] > span')
   })
+
+  test('it should use data attributes throughout selector even when id is set', async () => {
+    await page.evaluate('window.eventRecorder._dataAttribute = "data-qa"')
+    await page.click('#link')
+
+    const event = (await waitForAndGetEvents(page, 1))[0]
+    expect(event.selector).toEqual('[data-qa="link"]')
+  })
+
+  test('it should use id throughout selector when data attributes is not set', async () => {
+    await page.evaluate('window.eventRecorder._dataAttribute = null')
+    await page.click('#link')
+
+    const event = (await waitForAndGetEvents(page, 1))[0]
+    expect(event.selector).toEqual('#link')
+  })
 })

--- a/src/content-scripts/__tests__/fixtures/attributes.html
+++ b/src/content-scripts/__tests__/fixtures/attributes.html
@@ -12,6 +12,7 @@
       <span>Read More...</span>
     </div>
   </div>
+  <a href="#" id="link" data-qa="link">Click here</a>
 </div>
 <script src="/build/content-script.js" ></script>
 </body>

--- a/src/options/components/App.vue
+++ b/src/options/components/App.vue
@@ -18,6 +18,7 @@
               <input id="options-code-dataAttribute" type="text" v-model.trim="options.code.dataAttribute" @change="save" placeholder="your custom data-* attribute">
               <small>Define an attribute that we'll attempt to use when selecting the elements, i.e "data-custom". This is handy
                 when React or Vue based apps generate random class names.</small>
+              <small class="settings-warning">⚠️ When data attribute is set, it will take precedence from over other any selector (even ID)</small>
             </div>
             <div class="settings-group">
               <label class="settings-label">set key code</label>
@@ -215,11 +216,20 @@
           margin-bottom: $spacer;
         }
 
+        .settings-warning {
+          display: block;
+          font-size: .75rem;
+          font-weight: 500;
+          color: $pink;
+          margin: $spacer 0;
+        }
+
         .settings-block-title {
           margin: 0;
           padding-bottom: $spacer;
           border-bottom: 1px solid $gray-light;
         }
+
         .settings-block-main {
           padding: $spacer 0;
           margin-bottom: $spacer;


### PR DESCRIPTION
# Give precedence to `data-*` and trust in ID's uniqueness 

## Description

Introducing small improvements in selectors logic:
- When `data-*` is set, it will take precedence from over any other selector
- If target selector is based on `data-*` (and it was set) or `id`, will generate a shorter output based only on those attributes (`data-*` or `id`)

Add a label to settings page in order to inform users about this behaviour

<img width="536" alt="Screen Shot 2021-01-18 at 23 37 13" src="https://user-images.githubusercontent.com/3258966/104981964-62372d00-59e8-11eb-85e0-cb0d0bd32b97.png">

Fix https://github.com/checkly/headless-recorder/issues/60

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

New tests cases were created in `attributes.spec.js`

1. Checks that `data-*` will be used even if `id` is present
2. Checks that a target based on `id` selector will generate a shorter output based only on `id`

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.

