### PR TITLE
Make overlay copy default tab code

### DIFF
--- a/src/background/index.js
+++ b/src/background/index.js
@@ -190,13 +190,13 @@ class Background {
     }
 
     if (control === overlayActions.COPY) {
-      const { options = {} } = storage.get(['options'])
+      const { options = {} } = await storage.get('options')
       const generator = new CodeGenerator(options)
       const code = generator.generate(this._recording)
 
       browser.sendTabMessage({
         action: 'CODE',
-        value: !options?.code?.showPlaywrightFirst ? code.puppeteer : code.playwright,
+        value: options?.code?.showPlaywrightFirst ? code.playwright : code.puppeteer,
       })
     }
 


### PR DESCRIPTION
# Make overlay copy default tab code

## Description
Make overlay copy the default tab code based on `Show Playwright tab first` option.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
