### PR TITLE
Fix broken image paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ This project builds on existing open source projects (see [Credits](#-credits)) 
 3. Click on links, inputs and other elements.
 4. Wait for full page load on each navigation.
 
-    **The icon will switch from <img width="24px" height="24px" src="./chrome-store/rec.png" alt="recording icon"/>
-    to <img width="24px" height="24px" src="./chrome-store/wait.png" alt="waiting icon"/> to indicate it is ready for more input from you.**
+    **The icon will switch from <img width="24px" height="24px" src="./assets/rec.png" alt="recording icon"/>
+    to <img width="24px" height="24px" src="./assets/wait.png" alt="waiting icon"/> to indicate it is ready for more input from you.**
 
 5. Click Pause when you want to navigate without recording anything. Hit Resume to continue recording.
 
@@ -110,7 +110,7 @@ $ npm run build # build and zip for production
 1. Make sure "**Developer mode**" is enabled.
 1. Click "**Load unpacked extension**" button, browse the `headless-recorder/dist` directory and select it.
 
-![](./chrome-store/dev-guide.png)
+![](./assets/dev-guide.png)
 
 <br>
 


### PR DESCRIPTION
## Description

`README.md` has three broken images. This is because the image path is not correct. This PR replaces `./chrome-store/` with `./assets/` in those paths.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

You can confirm the change to fix images on this forked branch: https://github.com/shuuji3/headless-recorder/tree/fix-image-path

I couldn't pass the `npm run test` on my environment but it should pass because this PR only changes `README.md`.

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
