### PR TITLE
Use alt-k as shortcut as ctrl-k is already taken in the browser by ch…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ This project builds on existing open source projects (see [Credits](#-credits)) 
 
 ### ⌨️ Shortcuts
 
-- `ctrl + k`: Toggle overlay
-- `ctrl + shift + F`: Take full page screenshot
-- `ctrl + shift + E`: Take element screenshot
+- `alt + k`: Toggle overlay
+- `alt + shift + F`: Take full page screenshot
+- `alt + shift + E`: Take element screenshot
 
 <br>
 

--- a/src/modules/overlay/Overlay.vue
+++ b/src/modules/overlay/Overlay.vue
@@ -39,7 +39,7 @@
         REC
       </div>
       <span class="hr-shortcut">
-        ctrl + k to hide
+        alt + k to hide
       </span>
       <button
         class="hr-btn"
@@ -63,7 +63,7 @@
         :disabled="isPaused"
         class="hr-btn-big"
         @click.prevent="fullScreenshot"
-        v-tippy="{ content: 'Full Screenshot (ctrl+shift+F)', appendTo: 'parent' }"
+        v-tippy="{ content: 'Full Screenshot (alt+shift+F)', appendTo: 'parent' }"
       >
         <img width="27" height="27" :src="getIcon('screen')" alt="full page sreenshot" />
       </button>
@@ -71,7 +71,7 @@
         :disabled="isPaused"
         class="hr-btn-big"
         @click.prevent="clippedScreenshot"
-        v-tippy="{ content: 'Element Screenshot (ctrl+shift+E)', appendTo: 'parent' }"
+        v-tippy="{ content: 'Element Screenshot (alt+shift+E)', appendTo: 'parent' }"
       >
         <img width="27" height="27" :src="getIcon('clip')" alt="clipped sreenshot" />
       </button>
@@ -144,7 +144,7 @@ export default {
     },
 
     keyupListener(e) {
-      if (!e.ctrlKey) {
+      if (!e.altKey) {
         return
       }
 


### PR DESCRIPTION
## Description

When I'm trying to type ctrl-k to hide the overlay, I'm going into the google search functionality of Chrome. So I have rebound all the shortcuts with alt instead of ctrl.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
