### PR TITLE
Add Jest template next to puppeteer and Playwright

### DIFF
--- a/src/modules/code-generator/constants.js
+++ b/src/modules/code-generator/constants.js
@@ -22,4 +22,5 @@ export const eventsToRecord = {
 export const headlessTypes = {
   PUPPETEER: 'puppeteer',
   PLAYWRIGHT: 'playwright',
+  JEST: 'jest',
 }

--- a/src/modules/code-generator/index.js
+++ b/src/modules/code-generator/index.js
@@ -1,16 +1,19 @@
 import PuppeteerCodeGenerator from '@/modules/code-generator/puppeteer'
 import PlaywrightCodeGenerator from '@/modules/code-generator/playwright'
+import JestCodeGenerator from '@/modules/code-generator/jest'
 
 export default class CodeGenerator {
   constructor(options = {}) {
     this.puppeteerGenerator = new PuppeteerCodeGenerator(options)
     this.playwrightGenerator = new PlaywrightCodeGenerator(options)
+    this.jestGenerator = new JestCodeGenerator(options)
   }
 
   generate(recording) {
     return {
       puppeteer: this.puppeteerGenerator.generate(recording),
       playwright: this.playwrightGenerator.generate(recording),
+      jest: this.jestGenerator.generate(recording),
     }
   }
 }

--- a/src/modules/code-generator/jest.js
+++ b/src/modules/code-generator/jest.js
@@ -1,0 +1,35 @@
+import Block from '@/modules/code-generator/block'
+import { headlessActions } from '@/modules/code-generator/constants'
+import BaseGenerator from '@/modules/code-generator/base-generator'
+
+const header = `describe("Scenario 1", () => {
+	beforeAll(async () => {
+		jest.setTimeout(20000); // allow longer than 5 sec default for page load waits
+	});
+    
+    it("Testcase 1", async () => {`
+
+const footer = `	});
+});`
+
+export default class JestCodeGenerator extends BaseGenerator {
+  constructor(options) {
+    super(options)
+    this._header = header
+    this._footer = footer
+    this._wrappedHeader = header
+    this._wrappedFooter = footer
+  }
+
+  generate(events) {
+    return this._getHeader() + this._parseEvents(events) + this._getFooter()
+  }
+
+  _handleViewport(width, height) {
+    return new Block(this._frameId, {
+      type: headlessActions.VIEWPORT,
+      value: `await ${this._frame}.setViewport({ width: ${width}, height: ${height} })`,
+    })
+  }
+}
+

--- a/src/popup/PopupApp.vue
+++ b/src/popup/PopupApp.vue
@@ -17,6 +17,7 @@
     <Results
       :puppeteer="code"
       :playwright="codeForPlaywright"
+      :jest="codeForJest"
       :options="options"
       v-if="showResultsTab"
       v-on:update:tab="currentResultTab = $event"
@@ -171,11 +172,12 @@ export default {
     async generateCode() {
       const { recording, options = { code: {} } } = await storage.get(['recording', 'options'])
       const generator = new CodeGenerator(options.code)
-      const { puppeteer, playwright } = generator.generate(recording)
+      const { puppeteer, playwright, jest } = generator.generate(recording)
 
       this.recording = recording
       this.code = puppeteer
       this.codeForPlaywright = playwright
+      this.codeForJest = jest
       this.showResultsTab = true
     },
 
@@ -190,6 +192,7 @@ export default {
         code = '',
         options,
         codeForPlaywright = '',
+        codeForJest = '',
         recording,
         clear,
         pause,
@@ -199,6 +202,7 @@ export default {
         'code',
         'options',
         'codeForPlaywright',
+        'codeForJest',
         'recording',
         'clear',
         'pause',
@@ -211,6 +215,7 @@ export default {
 
       this.code = code
       this.codeForPlaywright = codeForPlaywright
+      this.codeForJest = codeForJest
 
       if (this.isRecording) {
         this.liveEvents = recording
@@ -239,6 +244,7 @@ export default {
       storage.set({
         code: this.code,
         codeForPlaywright: this.codeForPlaywright,
+        codeForJest: this.codeForJest,
         controls: { isRecording: this.isRecording, isPaused: this.isPaused },
       })
     },

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -48,6 +48,10 @@ export default {
       type: String,
       default: '',
     },
+    jest: {
+      type: String,
+      default: '',
+    },
     options: {
       type: Object,
       default: () => ({}),
@@ -57,13 +61,21 @@ export default {
   data() {
     return {
       activeTab: headlessTypes.PLAYWRIGHT,
-      tabs: [headlessTypes.PLAYWRIGHT, headlessTypes.PUPPETEER],
+      tabs: [headlessTypes.PLAYWRIGHT, headlessTypes.PUPPETEER, headlessTypes.JEST],
     }
   },
 
   computed: {
     code() {
-      return this.activeTab === headlessTypes.PUPPETEER ? this.puppeteer : this.playwright
+      if (this.activeTab === headlessTypes.PUPPETEER) {
+        return this.puppeteer
+      } else if (this.activeTab === headlessTypes.PLAYWRIGHT) {
+        return this.playwright
+      } else if (this.activeTab === headlessTypes.JEST) {
+        return this.jest
+      } else {
+        return this.puppeteer
+      }
     },
   },
 


### PR DESCRIPTION
## Description

As jest is more and more used for e2e testing, it would be awesome to also have this template.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

internal use

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
