### PR TITLE
Make it possible to customize selector resolver

### DIFF
--- a/src/content-scripts/controller.js
+++ b/src/content-scripts/controller.js
@@ -20,10 +20,11 @@ export default class HeadlessController {
     const { options } = await storage.get(['options'])
 
     const darkMode = options && options.extension ? options.extension.darkMode : isDarkMode()
-    const { dataAttribute } = options ? options.code : {}
+    const { dataAttribute, resolverAttribute } = options ? options.code : {}
 
     this.store.commit('setDarkMode', darkMode)
     this.store.commit('setDataAttribute', dataAttribute)
+    this.store.commit('setResolverAttribute', resolverAttribute)
 
     this.recorder.init(() => this.listenBackgroundMessages())
   }

--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -8,6 +8,7 @@ export const defaults = {
   waitForSelectorOnClick: true,
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
+  resolverAttribute: '',
   showPlaywrightFirst: true,
   keyCode: 9,
 }
@@ -142,10 +143,17 @@ export default class BaseGenerator {
         value: `await ${this._frame}.waitForSelector('${selector}')`,
       })
     }
-    block.addLine({
-      type: eventsToRecord.CLICK,
-      value: `await ${this._frame}.click('${selector}')`,
-    })
+    if (!selector.startsWith('xpath:')) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.click('${selector}')`,
+      })
+    } else {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `(await ${this._frame}.$x('${selector.substr(6)}'))[0].click()`,
+      })
+    }
     return block
   }
 

--- a/src/modules/overlay/index.js
+++ b/src/modules/overlay/index.js
@@ -49,10 +49,13 @@ export default class Overlay {
       .mount('#' + overlaySelectors.OVERLAY_ID)
 
     this.mouseOverEvent = e => {
-      const selector = getSelector(e, { dataAttribute: this.store.state.dataAttribute })
-      this.overlayApp.currentSelector = selector.includes('#' + overlaySelectors.OVERLAY_ID)
-        ? ''
-        : selector
+      const selector = getSelector(e, {
+        dataAttribute: this.store.state.dataAttribute,
+        resolverAttribute: this.store.state.resolverAttribute,
+        exclude: overlaySelectors.OVERLAY_ID,
+      })
+
+      this.overlayApp.currentSelector = selector === false ? '' : selector
 
       if (
         this.overlayApp.currentSelector &&

--- a/src/modules/recorder/index.js
+++ b/src/modules/recorder/index.js
@@ -67,9 +67,13 @@ export default class Recorder {
     // we explicitly catch any errors and swallow them, as none node-type events are also ingested.
     // for these events we cannot generate selectors, which is OK
     try {
-      const selector = getSelector(e, { dataAttribute: this.store.state.dataAttribute })
+      const selector = getSelector(e, {
+        dataAttribute: this.store.state.dataAttribute,
+        resolverAttribute: this.store.state.resolverAttribute,
+        exclude: overlaySelectors.OVERLAY_ID,
+      })
 
-      if (selector.includes('#' + overlaySelectors.OVERLAY_ID)) {
+      if (selector === false) {
         return
       }
 

--- a/src/modules/shooter/index.js
+++ b/src/modules/shooter/index.js
@@ -23,10 +23,17 @@ class Shooter extends EventEmitter {
   }
 
   mouseover(e) {
-    this.currentSelctor = getSelector(e, { dataAttribute: this.store.state.dataAttribute }).replace(
-      '.' + overlaySelectors.CURSOR_CAMERA_CLASS,
-      'body'
-    )
+    const selector = getSelector(e, {
+      dataAttribute: this.store.state.dataAttribute,
+      resolverAttribute: this.store.data.resolverAttribute,
+      exclude: overlaySelectors.OVERLAY_ID,
+    })
+
+    if (selector === false) {
+      return
+    }
+
+    this.currentSelctor = selector.replace('.' + overlaySelectors.CURSOR_CAMERA_CLASS, 'body')
   }
 
   startScreenshotMode() {

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -67,6 +67,17 @@
             will not handle multiple keys.
           </p>
         </div>
+        <div>
+          <label>Set custom selector resolver</label>
+          <textarea
+            id="custom-data-resolver"
+            class="w-full placeholder-gray-darkish bg-gray-lighter rounded px-2 mb-2 text-sm"
+            type="text"
+            v-model.trim="options.code.resolverAttribute"
+            @change="save"
+            rows="10"
+          />
+        </div>
       </section>
 
       <section>

--- a/src/services/selector.js
+++ b/src/services/selector.js
@@ -1,6 +1,22 @@
 import { finder } from '@medv/finder/finder.js'
 
-export default function selector(e, { dataAttribute } = {}) {
+export default function selector(e, { dataAttribute, resolverAttribute, exclude } = {}) {
+  let parent = e.target
+  while (parent && parent.id != exclude) {
+    parent = parent.parentNode
+  }
+  if (parent && parent.id == exclude) {
+    return false
+  }
+
+  if (resolverAttribute) {
+    const resolver = new Function('element', resolverAttribute)
+    const ret = resolver(e.target)
+    if (typeof ret == 'string') {
+      return ret
+    }
+  }
+
   if (dataAttribute && e.target.getAttribute(dataAttribute)) {
     return `[${dataAttribute}="${e.target.getAttribute(dataAttribute)}"]`
   }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -25,6 +25,8 @@ const store = createStore({
       hasRecorded: false,
 
       dataAttribute: '',
+      resolverAttribute: '',
+
       takeScreenshot: false,
 
       recording: [],
@@ -48,6 +50,10 @@ const store = createStore({
 
     setDataAttribute(state, dataAttribute) {
       state.dataAttribute = dataAttribute
+    },
+
+    setResolverAttribute(state, resolverAttribute) {
+      state.resolverAttribute = resolverAttribute
     },
 
     setDarkMode(state, darkMode) {


### PR DESCRIPTION
## Description

I saw a lot off comments about changing the selector. Using not class based selector, but something other. As all programmers and projects have their own requirements. I have made the resolver programmable. So that the user can set their own resolver in the settings. With that settings, it still uses the same method as before.

I for example use the following resolver in the settings. It is based on text instead of classnames. This is just so that other persons have an example of how the resolver could look like with the new setting.
```
const filter = function(element) {
  return Array.from(element.childNodes).filter((node) =>node.textContent.replaceAll("&nbsp;", "").trim() != "");
}

while(filter(element).length == 1) {
  let newElement = filter(element)[0]
  if(newElement.nodeName == "#text")
    break;
  element = newElement;
}

var text = element.textContent.trim();
if(text.indexOf('\n') == -1 && text.indexOf('"') == -1 && text.indexOf("'") == -1) {
  var found = document.evaluate("//*[text()='"+text+"']", document, null, XPathResult.UNORDERED_NODE_ITERATOR_TYPE).iterateNext()

  if(found && found == element) {
    return "xpath://*[text()=\""+text+"\"]"
  }
}
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Used it internally

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
