### PR TITLE
Make it possible to use page.keyboard.type('text') instead of page.ty…

### DIFF
--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -9,6 +9,7 @@ export const defaults = {
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
   showPlaywrightFirst: true,
+  typeWithSelector: true,
   keyCode: 9,
 }
 
@@ -127,10 +128,17 @@ export default class BaseGenerator {
 
   _handleKeyDown(selector, value) {
     const block = new Block(this._frameId)
-    block.addLine({
-      type: eventsToRecord.KEYDOWN,
-      value: `await ${this._frame}.type('${selector}', '${this._escapeUserInput(value)}')`,
-    })
+    if (this._options.typeWithSelector) {
+      block.addLine({
+        type: eventsToRecord.KEYDOWN,
+        value: `await ${this._frame}.type('${selector}', '${this._escapeUserInput(value)}')`,
+      })
+    } else {
+      block.addLine({
+        type: eventsToRecord.KEYDOWN,
+        value: `await ${this._frame}.keyboard.type('${this._escapeUserInput(value)}')`,
+      })
+    }
     return block
   }
 

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -84,6 +84,9 @@
           Add <code>waitForSelector</code> lines before every
           <code>page.click()</code>
         </Toggle>
+        <Toggle v-model="options.code.typeWithSelector">
+          Use a selector with the <code>type</code> lines
+        </Toggle>
         <Toggle v-model="options.code.blankLinesBetweenBlocks">
           Add blank lines between code blocks
         </Toggle>


### PR DESCRIPTION
## Description

The selectors are sometimes cryptic and could break with adaptations in the DOM layout. Thus I use a custom selector (see other pull request). But the couldn't find a proper selector to use with typing in a field. Thus I made it possible that no selector is used and the function page.keyboard.type('text') is used. When testing I first click on the label and then type. So the duplicate selector isn't needed. I created an option to use the page.keyboard.type(). It is still defaulted to the page.type() function.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Internal testing

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
