### PR TITLE
Add options to wait for network after a click

### DIFF
--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -6,6 +6,7 @@ export const defaults = {
   headless: true,
   waitForNavigation: true,
   waitForSelectorOnClick: true,
+  waitForNetworkIdleAfterClick: true,
   blankLinesBetweenBlocks: true,
   dataAttribute: '',
   showPlaywrightFirst: true,
@@ -146,6 +147,12 @@ export default class BaseGenerator {
       type: eventsToRecord.CLICK,
       value: `await ${this._frame}.click('${selector}')`,
     })
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.waitForNetworkIdle()`,
+      })
+    }
     return block
   }
 
@@ -157,10 +164,18 @@ export default class BaseGenerator {
   }
 
   _handleGoto(href) {
-    return new Block(this._frameId, {
+    const block = new Block(this._frameId)
+    block.addLine({
       type: headlessActions.GOTO,
       value: `await ${this._frame}.goto('${href}')`,
     })
+    if (this._options.waitForNetworkIdleAfterClick) {
+      block.addLine({
+        type: eventsToRecord.CLICK,
+        value: `await ${this._frame}.waitForNetworkIdle()`,
+      })
+    }
+    return block
   }
 
   _handleViewport() {

--- a/src/options/OptionsApp.vue
+++ b/src/options/OptionsApp.vue
@@ -84,6 +84,10 @@
           Add <code>waitForSelector</code> lines before every
           <code>page.click()</code>
         </Toggle>
+        <Toggle v-model="options.code.waitForNetworkIdleAfterClick">
+          Add <code>waitForNetwoorkIdle</code> lines after every <code>page.click()</code> or
+          <code>page.goto()</code>
+        </Toggle>
         <Toggle v-model="options.code.blankLinesBetweenBlocks">
           Add blank lines between code blocks
         </Toggle>


### PR DESCRIPTION
## Description

With a React application, a click doesn't always change the navigation. But in most cases will load some extra data. So add an option to wait after all network activity is done when clicking.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Internal testing

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
