### PR TITLE
Select some text and press tab will check for the presence in the page

### DIFF
--- a/src/modules/code-generator/base-generator.js
+++ b/src/modules/code-generator/base-generator.js
@@ -44,7 +44,17 @@ export default class BaseGenerator {
     if (!events) return result
 
     for (let i = 0; i < events.length; i++) {
-      const { action, selector, value, href, keyCode, tagName, frameId, frameUrl } = events[i]
+      const {
+        action,
+        selector,
+        value,
+        href,
+        keyCode,
+        tagName,
+        frameId,
+        frameUrl,
+        selection,
+      } = events[i]
       const escapedSelector = selector ? selector?.replace(/\\/g, '\\\\') : selector
 
       // we need to keep a handle on what frames events originate from
@@ -53,7 +63,11 @@ export default class BaseGenerator {
       switch (action) {
         case 'keydown':
           if (keyCode === this._options.keyCode) {
-            this._blocks.push(this._handleKeyDown(escapedSelector, value, keyCode))
+            if (value) {
+              this._blocks.push(this._handleKeyDown(escapedSelector, value, keyCode))
+            } else if (selection) {
+              this._blocks.push(this._handleSelection(escapedSelector, selection, keyCode))
+            }
           }
           break
         case 'click':
@@ -193,6 +207,13 @@ await element${this._screenshotCounter}.screenshot({ path: 'screenshot_${this._s
       })
     }
     return block
+  }
+
+  _handleSelection(selector, selection) {
+    return new Block(this._frameId, {
+      type: eventsToRecord.KEYDOWN,
+      value: `await expect(${this._frame}).toMatch('${selection}')`,
+    })
   }
 
   _postProcessSetFrames() {

--- a/src/modules/recorder/index.js
+++ b/src/modules/recorder/index.js
@@ -13,6 +13,7 @@ export default class Recorder {
     this._isRecordingClicks = true
 
     this.store = store
+    this.dragging = false
   }
 
   init(cb) {
@@ -20,6 +21,8 @@ export default class Recorder {
 
     if (!window.pptRecorderAddedControlListeners) {
       this._addAllListeners(events)
+      window.addEventListener('mousedown', () => (this.dragging = false))
+      window.addEventListener('mousemove', () => (this.dragging = true))
       cb && cb()
       window.pptRecorderAddedControlListeners = true
     }
@@ -46,6 +49,10 @@ export default class Recorder {
   _sendMessage(msg) {
     // filter messages based on enabled / disabled features
     if (msg.action === 'click' && !this._isRecordingClicks) {
+      return
+    }
+
+    if (msg.action === 'click' && this.dragging) {
       return
     }
 
@@ -82,6 +89,7 @@ export default class Recorder {
         action: e.type,
         keyCode: e.keyCode ? e.keyCode : null,
         href: e.target.href ? e.target.href : null,
+        selection: window.getSelection().toString(),
         coordinates: Recorder._getCoordinates(e),
       })
     } catch (err) {


### PR DESCRIPTION
## Description

In test you want to check if some text is included in the page. That wasn't possible yet with the current recoder. I made it possible by selecting the text and then press the tab (so the key code). Then it will add a code block that will check if the selected text is present.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. 

## Checklist:

- [x] My code follows the style guidelines of this project. `npm run lint` passes with no errors.
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes. `npm run test` passes with no errors.
