### PR TITLE
Adding automated extension submission via github action

### DIFF
--- a/.github/workflows/lint-build-test.yml
+++ b/.github/workflows/lint-build-test.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        cache: 'npm'
     - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
     - uses: actions/cache@v1
       id: cache-dependencies

--- a/.github/workflows/submit.yml
+++ b/.github/workflows/submit.yml
@@ -1,0 +1,28 @@
+name: Submit extension
+
+on:
+  workflow_dispatch:
+
+jobs:
+  submit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+        cache: 'npm'
+    - run: PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm install
+    - name: Lint
+      run: npm run lint
+    - name: Build
+      run: npm run build
+    - name: Get artifact info
+      id: get_artifact_info
+      run: |
+        echo "::set-output name=fileName::$(ls artifacts | head -n 1)"
+    - name: Browser Plugin Publish
+      uses: plasmo-corp/bpp@v1
+      with:
+        artifact: "artifacts/${{ steps.get_artifact_info.outputs.fileName }}"
+        keys: ${{ secrets.SUBMIT_KEYS }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ pnpm-debug.log*
 *.pub
 *.zip
 /artifacts
+
+# Key files
+keys.json


### PR DESCRIPTION
# Pull Request Template

## Description

Hi friends! Thanks for making this extension, it has been extremely helpful in my workflow.  Was looking for some way to contribute, and thought that maybe an automated submission pipeline for the built zip could be helpful. 

I created a github action called [bpp](https://github.com/marketplace/actions/browser-plugin-publisher) that can submit the zip to the every stores automatically (Safari is in the pipeline). I've set it to run manually from the github action tab, but we can tweak it to run as frequent as needed! I've also fixed the github action to use node14 since that's what was used for the current lockfile.

The only thing you would need to create is a `SUBMIT_KEYS` github repository secret. This secret is a json, with the schema defined [here](https://github.com/plasmo-corp/bpp/blob/main/keys.schema.json).

Here's a sample key:

```json
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "./extension.crx",
    "clientId": "123",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "./extension.xpi",
    "extId": "123",
    "apiKey": "abcd",
    "apiSecret": "efgh"
  }
}

```

You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me! Otherwise if this doesn't seem necessary, feel free to close the PR :)

## Type of change

- [x] Devops

## How Has This Been Tested?

I have tested this action in my own fork: https://github.com/plasmo-corp/headless-recorder/runs/5257804875?check_suite_focus=true#logs

Ref #122 